### PR TITLE
added classification as CAR to published traffic participant

### DIFF
--- a/src/simulated_vehicle_node.cpp
+++ b/src/simulated_vehicle_node.cpp
@@ -234,6 +234,7 @@ SimulatedVehicleNode::publish_vehicle_states()
   traffic_participant.state                = current_vehicle_state;
   traffic_participant.physical_parameters  = model.params;
   traffic_participant.state.time           = current_time.seconds();
+  traffic_participant.classification = dynamics::TrafficParticipantClassification::CAR;
   auto noisy_state                         = current_vehicle_state;
   auto generator                           = std::default_random_engine( std::chrono::system_clock::now().time_since_epoch().count() );
   noisy_state.x                           += pos_noise( generator );


### PR DESCRIPTION
The traffic participant published by simulated vehicles now include a classification as car aswell.